### PR TITLE
layout improvements

### DIFF
--- a/frontend/src/components/Transforms/Image.js
+++ b/frontend/src/components/Transforms/Image.js
@@ -14,17 +14,8 @@ const Image = ({ src, alt }) => {
 export default Image
 
 const Img = styled.img`
-  max-width: 50%;
+  max-width: 100%;
   margin: 3rem 0;
-  transition: 300ms ease-out max-width;
-
-  @media (max-width: 900px) {
-    max-width: 75%;
-  }
-
-  @media (max-width: 600px) {
-    max-width: 100%;
-  }
 `
 
 const Wrapper = styled.div`

--- a/frontend/src/design-system/CategoryList/CategoryList.js
+++ b/frontend/src/design-system/CategoryList/CategoryList.js
@@ -8,7 +8,7 @@ const CategoryList = ({ posts }) => {
   return (
     <Container>
       {posts.map(post => (
-        <Post key={post.id} post={post} />
+        <Post key={post.strapiId} post={post} />
       ))}
     </Container>
   )

--- a/frontend/src/design-system/PostCard/PostCard.js
+++ b/frontend/src/design-system/PostCard/PostCard.js
@@ -1,11 +1,17 @@
 import React, { useContext } from "react"
-import { arrayOf, number, object, oneOf, shape, string } from "prop-types"
+import { arrayOf, bool, number, object, oneOf, shape, string } from "prop-types"
 import styled, { ThemeContext } from "styled-components"
 import BackgroundImage from "gatsby-background-image"
 import { Flex, Link, UserCard } from ".."
 import { setUrl } from "../../utils"
 
-const PostCard = ({ post, type = "blog", padding, zoom = true }) => {
+const PostCard = ({
+  post,
+  type = "blog",
+  padding,
+  zoom = true,
+  shrink = true,
+}) => {
   const {
     thumbnail: {
       localFile: {
@@ -19,7 +25,7 @@ const PostCard = ({ post, type = "blog", padding, zoom = true }) => {
   const avatarSize = post.authors?.length > 2 ? "micro" : "small"
 
   return (
-    <CardLink to={url} zoom={zoom}>
+    <CardLink to={url} zoom={zoom} shrink={shrink}>
       <Card fluid={thumbnail} padding={padding} type={type}>
         <TextContainer type={type}>
           <Title>{post.title}</Title>
@@ -53,6 +59,8 @@ PostCard.propTypes = {
   }),
   type: oneOf(["blog", "project", "release", "community"]).isRequired,
   padding: string,
+  zoom: bool,
+  shrink: bool,
 }
 
 export default PostCard
@@ -89,7 +97,7 @@ const CardLink = styled(Link)`
 
   :active {
     opacity: 1;
-    transform: scale(0.98) translate(0px, 0px);
+    transform: ${({ shrink }) => shrink && `scale(0.98) translate(0px, 0px)`};
     box-shadow: 0px 0px 0px ${props => props.theme.colors.box_shadow};
   }
 `

--- a/frontend/src/design-system/ReleaseCard/ReleaseCard.js
+++ b/frontend/src/design-system/ReleaseCard/ReleaseCard.js
@@ -143,6 +143,7 @@ const Byline = styled(Flex)`
 
   p:first-child {
     font-weight: bold;
+    margin-right: 2.5rem;
   }
 
   p,

--- a/frontend/src/design-system/globalStyles.js
+++ b/frontend/src/design-system/globalStyles.js
@@ -123,7 +123,7 @@ const GlobalStyles = createGlobalStyle`
         min-height: 40rem;
     }
 
-    video {
+    video, ul, ol {
         margin-bottom: 2rem;
     }
 

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -10,11 +10,17 @@ const IndexPage = ({
     allStrapiPost: { nodes: posts },
   },
 }) => {
-  const releasesAndProjects = posts.filter(
-    post => post.type === "release" || post.type === "project"
-  )
-  const recent = posts.filter(post => post.type === "blog" && post.authors[0])
-  const communityPosts = posts.filter(post => post.type === "community")
+  const releasesAndProjects = posts
+    .filter(post => post.type === "release" || post.type === "project")
+    .filter((_, idx) => idx <= 20)
+
+  const recent = posts
+    .filter(post => post.type === "blog" && post.authors[0])
+    .filter((_, idx) => idx <= 50)
+
+  const communityPosts = posts
+    .filter(post => post.type === "community")
+    .filter((_, idx) => idx <= 50)
 
   return (
     <Layout page="home">
@@ -107,6 +113,7 @@ export const query = graphql`
     allStrapiPost(
       filter: { skip_frontpage: { eq: false } }
       sort: { fields: published_date, order: DESC }
+      limit: 120
     ) {
       nodes {
         title

--- a/frontend/src/pages/projects.js
+++ b/frontend/src/pages/projects.js
@@ -23,6 +23,7 @@ const projects = ({
             padding="0"
             key={post.strapiId}
             zoom={false}
+            shrink={false}
           />
         ))}
       </PostsContainer>

--- a/frontend/src/pages/releases.js
+++ b/frontend/src/pages/releases.js
@@ -16,7 +16,7 @@ const releases = ({
     <Layout>
       <Head title="releases" />
       <Title>releases</Title>
-      <PostsContainer>
+      <PostsContainer releaseCount={safeReleases?.length}>
         {safeReleases.map(release => (
           <ReleaseCard
             post={release}
@@ -33,17 +33,27 @@ const releases = ({
 
 export default releases
 
+const setColumns = numReleases => {
+  switch (numReleases) {
+    case 1:
+    case 2:
+      return "repeat(2, 1fr)"
+    default:
+      return "repeat(3, 1fr)"
+  }
+}
+
 const PostsContainer = styled.div`
   margin: 4rem 0 6rem 0;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: ${({ releaseCount }) => setColumns(releaseCount)};
   grid-gap: 2rem;
 
   @media only screen and (max-width: 900px) {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @media only screen and (max-width: 500px) {
+  @media only screen and (max-width: 700px) {
     grid-template-columns: repeat(1, 1fr);
   }
 `

--- a/frontend/src/templates/postTemplate.js
+++ b/frontend/src/templates/postTemplate.js
@@ -14,42 +14,44 @@ const { baseMonoMixin } = theme.text
 const postLayout = ({ data: { strapiPost: post } }) => {
   return (
     <Layout>
-      <Head title={post.title} />
-      <PostHeader
-        authors={post.authors}
-        title={post.title}
-        publishDate={post.published_date}
-      />
+      <PostLayout>
+        <Head title={post.title} />
+        <PostHeader
+          authors={post.authors}
+          title={post.title}
+          publishDate={post.published_date}
+        />
 
-      <PostFormatting>
-        <MarkdownHTML source={post.body} />
-      </PostFormatting>
+        <PostFormatting>
+          <MarkdownHTML source={post.body} />
+        </PostFormatting>
 
-      <Links>
-        {post.links?.length ? (
-          <>
-            <LinkHeader>links:</LinkHeader>
-            <LinkGroup>
-              {post.links?.map(link => (
-                <Button key={link.id} href={link.url}>
-                  {link.title}
-                </Button>
-              ))}
-            </LinkGroup>
-          </>
-        ) : null}
+        <Links>
+          {post.links?.length ? (
+            <>
+              <LinkHeader>links:</LinkHeader>
+              <LinkGroup>
+                {post.links?.map(link => (
+                  <Button key={link.id} href={link.url}>
+                    {link.title}
+                  </Button>
+                ))}
+              </LinkGroup>
+            </>
+          ) : null}
 
-        {post.tags?.length ? (
-          <>
-            <LinkHeader>tags:</LinkHeader>
-            <LinkGroup>
-              {post.tags?.map(({ tag, id }) => (
-                <Tag key={id}>{tag}</Tag>
-              ))}
-            </LinkGroup>
-          </>
-        ) : null}
-      </Links>
+          {post.tags?.length ? (
+            <>
+              <LinkHeader>tags:</LinkHeader>
+              <LinkGroup>
+                {post.tags?.map(({ tag, id }) => (
+                  <Tag key={id}>{tag}</Tag>
+                ))}
+              </LinkGroup>
+            </>
+          ) : null}
+        </Links>
+      </PostLayout>
     </Layout>
   )
 }
@@ -59,6 +61,18 @@ postLayout.propTypes = {
 }
 
 export default postLayout
+
+const PostLayout = styled.div`
+  display: block;
+  width: calc(1920px - (65vw));
+  margin: 0 auto;
+  max-width: 100%;
+  transition: 0.2s ease-out all;
+
+  @media only screen and (min-width: 1921px) {
+    min-width: 600px;
+  }
+`
 
 const Links = styled.div`
   margin-top: 2rem;

--- a/frontend/src/templates/postTemplate.js
+++ b/frontend/src/templates/postTemplate.js
@@ -80,10 +80,12 @@ const Links = styled.div`
 
 const LinkGroup = styled.div`
   display: flex;
-  margin: 1rem 0 2rem 0;
+  flex-wrap: wrap;
+  margin: 1rem 0 1rem 0;
 
   a {
     margin-right: 1rem;
+    margin-bottom: 1rem;
   }
 `
 


### PR DESCRIPTION
- fix lack of whitespace following lists
- shrink overall post layout width
- restore post imgs to full-width (not an issue w/ the smaller overall width)
- fix post links overflowing on narrow screens
- limit overall # of posts that can be displayed on homepage
- fix `/projects` avatar link behavior
- fix release card byline spacing
- improve `/releases` layout rules