### PR TITLE
page-level metadata & fix netlify webhook body size exceeded

### DIFF
--- a/backend/api/author/models/author.settings.json
+++ b/backend/api/author/models/author.settings.json
@@ -33,8 +33,8 @@
       "required": true
     },
     "posts": {
-      "collection": "post",
-      "via": "authors"
+      "via": "authors",
+      "collection": "post"
     },
     "user": {
       "plugin": "users-permissions",

--- a/backend/api/author/models/author.settings.json
+++ b/backend/api/author/models/author.settings.json
@@ -33,8 +33,8 @@
       "required": true
     },
     "posts": {
-      "via": "authors",
-      "collection": "post"
+      "collection": "post",
+      "via": "authors"
     },
     "user": {
       "plugin": "users-permissions",

--- a/backend/api/post/models/post.settings.json
+++ b/backend/api/post/models/post.settings.json
@@ -42,8 +42,8 @@
       "default": false
     },
     "authors": {
-      "collection": "author",
       "via": "posts",
+      "collection": "author",
       "dominant": true
     },
     "tags": {

--- a/backend/api/post/models/post.settings.json
+++ b/backend/api/post/models/post.settings.json
@@ -42,8 +42,8 @@
       "default": false
     },
     "authors": {
-      "via": "posts",
       "collection": "author",
+      "via": "posts",
       "dominant": true
     },
     "tags": {
@@ -66,6 +66,11 @@
       ],
       "default": "blog",
       "required": true
+    },
+    "SEO": {
+      "type": "component",
+      "repeatable": false,
+      "component": "seo.seo"
     }
   }
 }

--- a/backend/components/gallery/gallery-item.json
+++ b/backend/components/gallery/gallery-item.json
@@ -24,9 +24,6 @@
     "link": {
       "type": "string"
     },
-    "authors": {
-      "collection": "author"
-    },
     "description": {
       "type": "string"
     }

--- a/backend/components/seo/seo.json
+++ b/backend/components/seo/seo.json
@@ -1,0 +1,14 @@
+{
+  "collectionName": "components_seo_seos",
+  "info": {
+    "name": "SEO",
+    "icon": "atlas"
+  },
+  "options": {},
+  "attributes": {
+    "description": {
+      "type": "text",
+      "maxLength": 160
+    }
+  }
+}

--- a/frontend/src/components/Layout/Head.js
+++ b/frontend/src/components/Layout/Head.js
@@ -72,6 +72,14 @@ function Head({ description, lang, meta, title }) {
           name: `twitter:description`,
           content: metaDescription,
         },
+        {
+          name: "msapplication-TileColor",
+          content: "#191919",
+        },
+        {
+          name: "theme-color",
+          content: currentTheme.colors.scale_5,
+        },
       ].concat(meta)}
     >
       <link
@@ -83,8 +91,6 @@ function Head({ description, lang, meta, title }) {
       <link rel="icon" type="image/png" sizes="16x16" href={faviconSmall} />
       <link rel="manifest" href="/site.webmanifest" />
       <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#191919" />
-      <meta name="msapplication-TileColor" content="#191919" />
-      <meta name="theme-color" content={currentTheme.colors.scale_5} />
 
       <script type="text/javascript">
         {`

--- a/frontend/src/pages/about.js
+++ b/frontend/src/pages/about.js
@@ -4,6 +4,8 @@ import { Layout, Head } from "../components/Layout"
 import AboutSection from "../components/About/About"
 import { Flex } from "../design-system"
 
+const description = `glitch.cool is a collective of producers, sound designers, programmers, and visual artists orbiting the glitch aesthetic, founded in 2019.`
+
 const About = ({
   data: {
     allImageSharp: { nodes: images },
@@ -11,7 +13,7 @@ const About = ({
 }) => {
   return (
     <Layout>
-      <Head title="about" />
+      <Head title="about" description={description} />
       <Flex justify="center">
         <AboutSection images={images} />
       </Flex>

--- a/frontend/src/templates/postTemplate.js
+++ b/frontend/src/templates/postTemplate.js
@@ -8,6 +8,7 @@ import { Head, Layout } from "../components/Layout"
 import MarkdownHTML from "../components/Transforms/MarkdownHTML"
 import { Tag, Button } from "../design-system"
 import { lightTheme as theme } from "../design-system/theme"
+import { deriveDescriptionFromMarkdown } from "../utils"
 
 const { baseMonoMixin } = theme.text
 
@@ -15,7 +16,10 @@ const postLayout = ({ data: { strapiPost: post } }) => {
   return (
     <Layout>
       <PostLayout>
-        <Head title={post.title} />
+        <Head
+          title={post.title}
+          description={deriveDescriptionFromMarkdown(post.body)}
+        />
         <PostHeader
           authors={post.authors}
           title={post.title}

--- a/frontend/src/templates/postTemplate.js
+++ b/frontend/src/templates/postTemplate.js
@@ -18,7 +18,9 @@ const postLayout = ({ data: { strapiPost: post } }) => {
       <PostLayout>
         <Head
           title={post.title}
-          description={deriveDescriptionFromMarkdown(post.body)}
+          description={
+            post.SEO?.description || deriveDescriptionFromMarkdown(post.body)
+          }
         />
         <PostHeader
           authors={post.authors}
@@ -147,6 +149,9 @@ export const query = graphql`
         id
         title
         url
+      }
+      SEO {
+        description
       }
     }
   }

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -1,2 +1,4 @@
 export { default as slugify } from "./slugify"
 export { default as setUrl } from "./setUrl"
+export * from "./string"
+export * from "./markdown"

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -1,0 +1,27 @@
+import { truncateString } from "./string"
+
+export const deriveDescriptionFromMarkdown = markdown => {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(markdown, "text/html")
+  const walker = document.createTreeWalker(doc, NodeFilter.SHOW_TEXT)
+
+  const textList = []
+  let currentNode = walker.currentNode
+
+  while (currentNode) {
+    const { textContent } = currentNode
+    if (textContent && textContent !== "\n") {
+      textList.push(currentNode.textContent)
+    }
+    currentNode = walker.nextNode()
+  }
+
+  const str = textList.reduce((acc, cur) => (acc += formatLineBreaks(cur)), "")
+
+  return truncateString(str, 160)
+}
+
+const formatLineBreaks = str => {
+  // remove newline characters, then replace incidental double-periods w/ ". "
+  return str.replaceAll("\n", ".").replaceAll("..", ". ")
+}

--- a/frontend/src/utils/string.js
+++ b/frontend/src/utils/string.js
@@ -1,0 +1,5 @@
+export const truncateString = (str, limit = 150) => {
+  if (str.length <= limit) return str
+
+  return `${str.substring(0, limit)}...`
+}


### PR DESCRIPTION
- adds meta descriptions to page templates (all types) for SEO purposes
- fixes netlify webhook body exceeded errors

adds an SEO module to strapi, implemented in posts, where you can specify an explicit meta description, otherwise it falls back to the first 160 chars of a post body.